### PR TITLE
Update p1b1.py

### DIFF
--- a/Pilot1/P1B1/p1b1.py
+++ b/Pilot1/P1B1/p1b1.py
@@ -205,8 +205,16 @@ def load_data_orig(params, seed):
 
 
 def evaluate_autoencoder(y_pred, y_test):
-    mse = mean_squared_error(y_pred, y_test)
-    r2 = r2_score(y_test, y_pred)
-    corr, _ = pearsonr(y_pred.flatten(), y_test.flatten())
-    # print('Mean squared error: {}%'.format(mse))
+    try:
+        mse = mean_squared_error(y_pred, y_test)
+        r2 = r2_score(y_test, y_pred)
+        corr, _ = pearsonr(y_pred.flatten(), y_test.flatten())
+        # print('Mean squared error: {}%'.format(mse))
+    except:
+        #when nan or something else breaks mean_squared_error computation
+        # we may check earlier before computation also:
+        #np.isnan(y_pred).any() or np.isnan(y_test).any()):
+        r2 = 0
+        mse = 0
+        corr = 0
     return {'mse': mse, 'r2_score': r2, 'correlation': corr}


### PR DESCRIPTION
when nan or something else breaks mean_squared_error computation, we may check earlier before computation also:
        np.isnan(y_pred).any() or np.isnan(y_test).any()):

but a try/except block is better.