### PR TITLE
keras: import print_function for old python users

### DIFF
--- a/common/keras_utils.py
+++ b/common/keras_utils.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-
+from __future__ import print_function
 
 from keras import backend as K
 from keras import optimizers


### PR DESCRIPTION
The keras_utils.py code requires print() to be treated as a function.