### PR TITLE
Enable support for Tensorflow 2.0 in NT3

### DIFF
--- a/Pilot1/NT3/nt3_baseline_keras2.py
+++ b/Pilot1/NT3/nt3_baseline_keras2.py
@@ -6,13 +6,22 @@ import os
 import sys
 import gzip
 
-from keras import backend as K
+try:
+    from keras import backend as K
 
-from keras.layers import Input, Dense, Dropout, Activation, Conv1D, MaxPooling1D, Flatten
-from keras.optimizers import SGD, Adam, RMSprop
-from keras.models import Sequential, Model, model_from_json, model_from_yaml
-from keras.utils import np_utils
-from keras.callbacks import ModelCheckpoint, CSVLogger, ReduceLROnPlateau
+    from keras.layers import Input, Dense, Dropout, Activation, Conv1D, MaxPooling1D, Flatten
+    from keras.optimizers import SGD, Adam, RMSprop
+    from keras.models import Sequential, Model, model_from_json, model_from_yaml
+    from keras.utils import to_categorical
+    from keras.callbacks import ModelCheckpoint, CSVLogger, ReduceLROnPlateau
+except:
+    from tensorflow.keras import backend as K
+
+    from tensorflow.keras.layers import Input, Dense, Dropout, Activation, Conv1D, MaxPooling1D, Flatten
+    from tensorflow.keras.optimizers import SGD, Adam, RMSprop
+    from tensorflow.keras.models import Sequential, Model, model_from_json, model_from_yaml
+    from tensorflow.keras.utils import to_categorical
+    from tensorflow.keras.callbacks import ModelCheckpoint, CSVLogger, ReduceLROnPlateau
 
 from sklearn.metrics import accuracy_score
 from sklearn.preprocessing import StandardScaler, MinMaxScaler, MaxAbsScaler
@@ -49,8 +58,8 @@ def load_data(train_path, test_path, gParameters):
     df_y_train = df_train[:,0].astype('int')
     df_y_test = df_test[:,0].astype('int')
 
-    Y_train = np_utils.to_categorical(df_y_train,gParameters['classes'])
-    Y_test = np_utils.to_categorical(df_y_test,gParameters['classes'])
+    Y_train = to_categorical(df_y_train,gParameters['classes'])
+    Y_test = to_categorical(df_y_test,gParameters['classes'])
 
     df_x_train = df_train[:, 1:seqlen].astype(np.float32)
     df_x_test = df_test[:, 1:seqlen].astype(np.float32)

--- a/common/candle/__init__.py
+++ b/common/candle/__init__.py
@@ -55,7 +55,7 @@ from profiling_utils import stop_profiling
 
 # import benchmark-dependent utils
 import sys
-if 'keras' in sys.modules:
+if 'keras' in sys.modules or 'tensorflow' in sys.modules:
     print ('Importing candle utils for keras')
     #import from keras_utils
     #from keras_utils import dense

--- a/common/keras_utils.py
+++ b/common/keras_utils.py
@@ -1,15 +1,26 @@
 from __future__ import absolute_import
 
+try:
+    from keras import backend as K
+    from keras import optimizers
+    from keras import initializers
 
-from keras import backend as K
-from keras import optimizers
-from keras import initializers
+    from keras.layers import Dropout
+    from keras.callbacks import Callback, ModelCheckpoint
+    from keras.utils import get_custom_objects
+    from keras.metrics import binary_crossentropy, mean_squared_error, mean_absolute_error
+    from keras.models import Model
 
-from keras.layers import Dropout
-from keras.callbacks import Callback, ModelCheckpoint
-from keras.utils import get_custom_objects
-from keras.metrics import binary_crossentropy, mean_squared_error, mean_absolute_error
-from keras.models import Model
+except:
+    from tensorflow.keras import backend as K
+    from tensorflow.keras import optimizers
+    from tensorflow.keras import initializers
+
+    from tensorflow.keras.layers import Dropout
+    from tensorflow.keras.callbacks import Callback, ModelCheckpoint
+    from tensorflow.keras.utils import get_custom_objects
+    from tensorflow.keras.metrics import binary_crossentropy, mean_squared_error, mean_absolute_error
+    from tensorflow.keras.models import Model
 
 from scipy.stats.stats import pearsonr
 

--- a/common/solr_keras.py
+++ b/common/solr_keras.py
@@ -5,9 +5,12 @@ from datetime import datetime
 
 import numpy as np
 import requests
-from keras import backend as K
-from keras.callbacks import Callback
-
+try:
+    from keras import backend as K
+    from keras.callbacks import Callback
+except:
+    from tensorflow.keras import backend as K
+    from tensorflow.keras.callbacks import Callback
 
 def compute_trainable_params(model):
     """ Extract number of parameters from the given Keras model
@@ -21,9 +24,9 @@ def compute_trainable_params(model):
         python dictionary that contains trainable_params, non_trainable_params and total_params
     """
     trainable_count = int(
-        np.sum([K.count_params(p) for p in set(model.trainable_weights)]))
+        np.sum([K.count_params(p) for p in model.trainable_weights]))
     non_trainable_count = int(
-        np.sum([K.count_params(p) for p in set(model.non_trainable_weights)]))
+        np.sum([K.count_params(p) for p in model.non_trainable_weights]))
 
     return {'trainable_params': trainable_count,
             'non_trainable_params': non_trainable_count,


### PR DESCRIPTION
This PR makes changes to enable the NT3 model `nt3_baseline_keras2.py` to be run with Tensorflow 2.0 (which ships with its own version of Keras). Most of the changes involve trying to import packages from keras and, if it fails, import the same packages from tensorflow.keras.