### PR TITLE
Stash datafile numpy arrays and concatenate once

### DIFF
--- a/Pilot2/P2B1/p2b1.py
+++ b/Pilot2/P2B1/p2b1.py
@@ -263,8 +263,8 @@ class Candle_Molecular_Train():
 
             num_frames = X.shape[0]
 
-            xt_all = np.array([])
-            yt_all = np.array([])
+            xt_all = []
+            yt_all = []
 
             num_active_frames = random.sample(range(num_frames), int(self.sampling_density*num_frames))
 
@@ -298,12 +298,11 @@ class Candle_Molecular_Train():
                         exit()
                     yt = xt.copy()
 
-                if not len(xt_all):
-                    xt_all = np.expand_dims(xt, axis=0)
-                    yt_all = np.expand_dims(yt, axis=0)
-                else:
-                    xt_all = np.append(xt_all, np.expand_dims(xt, axis=0), axis=0)
-                    yt_all = np.append(yt_all, np.expand_dims(yt, axis=0), axis=0)
+                xt_all.append(np.expand_dims(xt, axis=0))
+                yt_all.append(np.expand_dims(yt, axis=0))
+
+            xt_all = np.concatenate(xt_all)
+            yt_all = np.concatenate(yt_all)
 
             yield files[f_ind], xt_all, yt_all
 


### PR DESCRIPTION
Avoid appending to xt_all and yt_all during datagen by stashing xt and yt arrays in a python list.

Concatenate all the xt and yt arrays after all datagen frames have been processed, to trigger memcopy only once.

Before this patch, p2b1_baseline_keras2.py on Haswell (Cooley at Argonne - E5-2620v3 x2, 384 GB RAM, K80 GPU) runs in 4590 seconds

After this patch, it runs in 3555 seconds, for a ~23% speedup.

In situations with limited memory bandwidth (such as when using Optane DC Memory, or external memory via the RAN project at Argonne), this would have a significantly higher impact.