### PR TITLE
Error in P3B7 prune.py: fix for error from pruning function remove() on line 237 in prune.py

### DIFF
--- a/Pilot3/P3B7/prune.py
+++ b/Pilot3/P3B7/prune.py
@@ -234,6 +234,6 @@ def remove_prune_masks(model: nn.Module):
             prune.remove(module, name='weight')
         # prune 20% of connections in all linear layers
         elif isinstance(module, torch.nn.Linear):
-            prune.remove(module, name='weight', amount=0.2)
+            prune.random_unstructured(module, name='weight', amount=0.2)
 
     return model


### PR DESCRIPTION
While running p3b7_baseline.py I'm getting the following error

```
Traceback (most recent call last):
  File "p3b7_baseline.py", line 206, in <module>
    main()
  File "p3b7_baseline.py", line 202, in main
    run(params)
  File "p3b7_baseline.py", line 197, in run
    model = remove_prune_masks(model)
  File "/p/project/scalasca/candle/Benchmarks/Pilot3/P3B7/prune.py", line 237, in remove_prune_masks
    prune.remove(module, name='weight', amount=0.2)
TypeError: remove() got an unexpected keyword argument 'amount'
```

After looking at the documentation for that [function](https://pytorch.org/docs/stable/generated/torch.nn.utils.prune.remove.html#torch.nn.utils.prune.remove), I switched remove() to random_unstructured() and did not get that error. 

So wanted to recommend this fix